### PR TITLE
[8.0][IMP] l10n_it_account: refund account for italian profit and los…

### DIFF
--- a/l10n_it_account/__openerp__.py
+++ b/l10n_it_account/__openerp__.py
@@ -21,14 +21,20 @@
 ##############################################################################
 {
     'name': 'Italian Localization - Account',
-    'version': '8.0.1.0.0',
+    'version': '8.0.1.1.0',
     'category': 'Hidden',
     'author': "Agile Business Group,Abstract,Odoo Community Association (OCA)",
     'website': 'http://www.odoo-italia.org',
     'license': 'AGPL-3',
-    "depends": ['account', 'l10n_it_fiscalcode', 'l10n_it_base'],
+    "depends": [
+        'account',
+        'l10n_it_fiscalcode',
+        'l10n_it_base'
+    ],
+
     "data": [
         'views/account_view.xml',
+        'views/res_partner_view.xml',
         'reports/account_reports_view.xml',
         'views/config_view.xml',
     ],

--- a/l10n_it_account/i18n/it.po
+++ b/l10n_it_account/i18n/it.po
@@ -9,13 +9,14 @@
 # Lorenzo Battistini <lorenzo.battistini@agilebg.com>, 2016
 # Paolo Valier, 2016
 # Paolo Valier, 2016-2017
+# Domenico Stragapede, 2018
 msgid ""
 msgstr ""
 "Project-Id-Version: l10n-italy (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-07-29 03:34+0000\n"
-"PO-Revision-Date: 2017-08-11 19:01+0000\n"
-"Last-Translator: Paolo Valier\n"
+"PO-Revision-Date: 2018-12-30 12:40+0000\n"
+"Last-Translator: Domenico Stragapede\n"
 "Language-Team: Italian (http://www.transifex.com/oca/OCA-l10n-italy-8-0/"
 "language/it/)\n"
 "Language: it\n"
@@ -77,24 +78,38 @@ msgstr "Codice fiscale:"
 
 #. module: l10n_it_account
 #: field:account.account,inverse_user_type:0
+#: code:addons/l10n_it_account/models/account.py:31
+#, python-format
 msgid "Inverse Account Type"
 msgstr "Tipo di conto inverso"
 
 #. module: l10n_it_account
 #: field:account.account,inverse_parent_id:0
+#: code:addons/l10n_it_account/models/account.py:40
+#, python-format
 msgid "Inverse Parent"
 msgstr "Inverse Parent"
 
 #. module: l10n_it_account
+#: model:ir.model,name:l10n_it_account.model_account_invoice
+msgid "Invoice"
+msgstr "Fattura"
+
+#. module: l10n_it_account
+#: model:ir.model,name:l10n_it_account.model_account_invoice_line
+msgid "Invoice Line"
+msgstr "Righe Fattura"
+
+#. module: l10n_it_account
 #: field:account.tax.code,is_base:0
 msgid "Is base"
-msgstr "È imponibile"
+msgstr "E' imponibile"
 
 #. module: l10n_it_account
 #: code:addons/l10n_it_account/models/account_tax.py:102
 #, python-format
 msgid "No base code found for tax code %s"
-msgstr ""
+msgstr "Nessun conto imponibile trovato per il conto imposta %s"
 
 #. module: l10n_it_account
 #: field:account.tax,nondeductible:0
@@ -105,7 +120,16 @@ msgstr "Indetraibile"
 #: code:addons/l10n_it_account/models/account_tax.py:111
 #, python-format
 msgid "Not every tax linked to tax code %s is linked to the same base code"
-msgstr ""
+msgstr "Non tutte le tasse collegate al conto imposta %s sono collegate allo stesso conto imponibile"
+
+#. module: l10n_it_account
+#: help:account.account,refund_invoice_account_id:0
+#: code:addons/l10n_it_account/models/account.py:50
+#, python-format
+msgid "On credit note invoice, use this account instead of the main account.\n"
+"In italian account chart, profit and loss accounts must be used as credit account or debit account only."
+msgstr "Nelle note di credito, utilizza questo conto invece di quello predefinito.\n"
+"Nel piano dei conti italiano, i conti economici devono essere unilaterati."
 
 #. module: l10n_it_account
 #: view:website:l10n_it_account.internal_layout
@@ -116,6 +140,18 @@ msgstr "Pag:"
 #: help:account.tax,nondeductible:0
 msgid "Partially or totally non-deductible."
 msgstr "Parzialmente o totalmente indetraibile"
+
+#. module: l10n_it_account
+#: model:ir.model,name:l10n_it_account.model_res_partner
+msgid "Partner"
+msgstr "Partner"
+
+#. module: l10n_it_account
+#: field:account.account,refund_invoice_account_id:0
+#: code:addons/l10n_it_account/models/account.py:49
+#, python-format
+msgid "Refund Invoice Account"
+msgstr "Conto Note Credito"
 
 #. module: l10n_it_account
 #: help:l10n_it.config.settings,skip_it_account_check:0
@@ -176,12 +212,14 @@ msgstr "Tipo"
 #. module: l10n_it_account
 #: help:account.account,inverse_parent_id:0
 #: help:account.account,inverse_user_type:0
+#: code:addons/l10n_it_account/models/account.py:32
+#, python-format
 msgid ""
 "Used on balance sheet to report this account when its balance is         "
 "negative"
 msgstr ""
-"Used on balance sheet to report this account when its balance is         "
-"negative"
+"Usato nella stampa del bilancio per riportalo in questo conto quando il suo "
+"importo totale è negativo"
 
 #. module: l10n_it_account
 #: view:account.tax.code:l10n_it_account.view_tax_code_form_vat

--- a/l10n_it_account/i18n/l10n_it_account.pot
+++ b/l10n_it_account/i18n/l10n_it_account.pot
@@ -6,6 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2018-12-30 12:40+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -66,12 +67,26 @@ msgstr ""
 
 #. module: l10n_it_account
 #: field:account.account,inverse_user_type:0
+#: code:addons/l10n_it_account/models/account.py:31
+#, python-format
 msgid "Inverse Account Type"
 msgstr ""
 
 #. module: l10n_it_account
 #: field:account.account,inverse_parent_id:0
+#: code:addons/l10n_it_account/models/account.py:40
+#, python-format
 msgid "Inverse Parent"
+msgstr ""
+
+#. module: l10n_it_account
+#: model:ir.model,name:l10n_it_account.model_account_invoice
+msgid "Invoice"
+msgstr ""
+
+#. module: l10n_it_account
+#: model:ir.model,name:l10n_it_account.model_account_invoice_line
+msgid "Invoice Line"
 msgstr ""
 
 #. module: l10n_it_account
@@ -97,6 +112,14 @@ msgid "Not every tax linked to tax code %s is linked to the same base code"
 msgstr ""
 
 #. module: l10n_it_account
+#: help:account.account,refund_invoice_account_id:0
+#: code:addons/l10n_it_account/models/account.py:50
+#, python-format
+msgid "On credit note invoice, use this account instead of the main account.\n"
+"In italian account chart, profit and loss accounts must be used as credit account or debit account only."
+msgstr ""
+
+#. module: l10n_it_account
 #: view:website:l10n_it_account.internal_layout
 msgid "Pag:"
 msgstr ""
@@ -104,6 +127,18 @@ msgstr ""
 #. module: l10n_it_account
 #: help:account.tax,nondeductible:0
 msgid "Partially or totally non-deductible."
+msgstr ""
+
+#. module: l10n_it_account
+#: model:ir.model,name:l10n_it_account.model_res_partner
+msgid "Partner"
+msgstr ""
+
+#. module: l10n_it_account
+#: field:account.account,refund_invoice_account_id:0
+#: code:addons/l10n_it_account/models/account.py:49
+#, python-format
+msgid "Refund Invoice Account"
 msgstr ""
 
 #. module: l10n_it_account
@@ -155,7 +190,9 @@ msgstr ""
 #. module: l10n_it_account
 #: help:account.account,inverse_parent_id:0
 #: help:account.account,inverse_user_type:0
-msgid "Used on balance sheet to report this account when its balance is         negative"
+#: code:addons/l10n_it_account/models/account.py:32
+#, python-format
+msgid "Used on balance sheet to report this account when its balance is negative"
 msgstr ""
 
 #. module: l10n_it_account

--- a/l10n_it_account/models/__init__.py
+++ b/l10n_it_account/models/__init__.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 
+from . import res_partner
 from . import account
+from . import account_invoice
+from . import account_invoice_line
 from . import account_tax
 from . import res_config

--- a/l10n_it_account/models/account.py
+++ b/l10n_it_account/models/account.py
@@ -3,6 +3,7 @@
 #
 #    Copyright (C) 2015 Abstract srl (<http://www.abstract.it>)
 #    Copyright (C) 2015 Agile Business Group sagl (<http://www.agilebg.com>)
+#    Copyright (C) 2018 ElvenStudio S.n.c. (<http://www.elvenstudio.it>)
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as
@@ -19,7 +20,7 @@
 #
 ##############################################################################
 
-from openerp import fields, models
+from openerp import fields, models, _
 
 
 class AccountAccount(models.Model):
@@ -27,11 +28,30 @@ class AccountAccount(models.Model):
 
     inverse_user_type = fields.Many2one(
         'account.account.type',
-        string='Inverse Account Type',
-        help="Used on balance sheet to report this account when its balance is \
-        negative")
+        string=_('Inverse Account Type'),
+        help=_(
+            "Used on balance sheet to report this account "
+            "when its balance is negative"
+        )
+    )
+
     inverse_parent_id = fields.Many2one(
         'account.account',
-        string='Inverse Parent',
-        help="Used on balance sheet to report this account when its balance is \
-        negative")
+        string=_('Inverse Parent'),
+        help=(
+            "Used on balance sheet to report this account "
+            "when its balance is negative"
+        )
+    )
+
+    refund_invoice_account_id = fields.Many2one(
+        'account.account',
+        string=_('Refund Invoice Account'),
+        help=_(
+            'On credit note invoice, use this account '
+            'instead of the main account.\n'
+            'In italian account chart, profit and loss accounts '
+            'must be used as credit account or debit account only.'
+        )
+    )
+

--- a/l10n_it_account/models/account_invoice.py
+++ b/l10n_it_account/models/account_invoice.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2018 ElvenStudio S.n.c. (<http://www.elvenstudio.it>)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, api
+
+
+class AccountInvoice(models.Model):
+    _inherit = 'account.invoice'
+
+    @api.model
+    def _refund_cleanup_lines(self, lines):
+        refund_lines = super(AccountInvoice, self)._refund_cleanup_lines(lines)
+
+        account_cls = self.env['account.account']
+        # override account_id if a refund account is defined
+        invoice_lines = []
+        for line in refund_lines:
+            if isinstance(line[2], dict):
+                account_id = line[2].get('account_id', False)
+                if account_id:
+                    account = account_cls.browse(account_id)
+                    if account and account.refund_invoice_account_id:
+                        line[2]['account_id'] = account.refund_invoice_account_id.id
+
+            invoice_lines.append(line)
+
+        return invoice_lines

--- a/l10n_it_account/models/account_invoice_line.py
+++ b/l10n_it_account/models/account_invoice_line.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2018 ElvenStudio S.n.c. (<http://www.elvenstudio.it>)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, api
+
+
+class AccountInvoiceLine(models.Model):
+    _inherit = "account.invoice.line"
+
+    @api.multi
+    def product_id_change(
+            self, product, uom_id, qty=0, name='', type='out_invoice',
+            partner_id=False, fposition_id=False, price_unit=False,
+            currency_id=False, company_id=None
+    ):
+        res = super(AccountInvoiceLine, self).product_id_change(
+            product, uom_id, qty=qty,
+            name=name, type=type, partner_id=partner_id,
+            fposition_id=fposition_id, price_unit=price_unit,
+            currency_id=currency_id,  company_id=company_id
+        )
+
+        account_cls = self.env['account.account']
+        # override account_id if refund invoice
+        if type in ('out_refund', 'in_refund'):
+            value = res.get('value', False)
+            if value and isinstance(value, dict):
+                account_id = value.get('account_id', False)
+                if account_id:
+                    account = account_cls.browse(account_id)
+                    if account and account.refund_invoice_account_id:
+                        res['value']['account_id'] = account.refund_invoice_account_id.id
+
+        return res
+

--- a/l10n_it_account/models/res_partner.py
+++ b/l10n_it_account/models/res_partner.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+#
+#
+#    Copyright (C) 2018 Elven Studio (<http://www.elvenstudio.it>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+from openerp import models, api
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    @api.model
+    def create(self, vals):
+        if 'vat' in vals and isinstance(vals['vat'], basestring):
+            # remove white space at the end of vat
+            vals['vat'] = vals['vat'].rstrip()
+
+        return super(ResPartner, self).create(vals)
+
+    @api.multi
+    def write(self, vals):
+        if 'vat' in vals and isinstance(vals['vat'], basestring):
+            # remove white space at the end of vat
+            vals['vat'] = vals['vat'].rstrip()
+
+        return super(ResPartner, self).write(vals)

--- a/l10n_it_account/views/account_view.xml
+++ b/l10n_it_account/views/account_view.xml
@@ -2,46 +2,64 @@
 <openerp>
     <data>
 
-      <record id="view_tax_code_form_vat" model="ir.ui.view">
-          <field name="name">account.tax.code.form.vat</field>
-          <field name="model">account.tax.code</field>
-          <field name="inherit_id" ref="account.view_tax_code_form"></field>
-          <field name="type">form</field>
-          <field name="arch" type="xml">
-              <separator string="Description" position="before">
-                  <group colspan="2" col="2">
-                      <separator string="VAT statement" colspan="4"/>
-                      <field name="vat_statement_type"/>
-                      <field name="is_base"/>
-                  </group>
-              </separator>
-          </field>
-      </record>
+        <record id="view_tax_code_form_vat" model="ir.ui.view">
+            <field name="name">account.tax.code.form.vat</field>
+            <field name="model">account.tax.code</field>
+            <field name="inherit_id" ref="account.view_tax_code_form" />
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <separator string="Description" position="before">
+                    <group colspan="2" col="2">
+                        <separator string="VAT statement" colspan="4"/>
+                        <field name="vat_statement_type"/>
+                        <field name="is_base"/>
+                    </group>
+                </separator>
+            </field>
+        </record>
 
-      <record id="view_tax_form_nondeductible" model="ir.ui.view">
-          <field name="name">account.tax.form.nondeductible</field>
-          <field name="model">account.tax</field>
-          <field name="inherit_id" ref="account.view_tax_form"></field>
-          <field name="type">form</field>
-          <field name="arch" type="xml">
-              <field name="child_depend" position="after">
-                  <field name="nondeductible"/>
-              </field>
-          </field>
-      </record>
+        <record id="view_tax_form_nondeductible" model="ir.ui.view">
+            <field name="name">account.tax.form.nondeductible</field>
+            <field name="model">account.tax</field>
+            <field name="inherit_id" ref="account.view_tax_form" />
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <field name="child_depend" position="after">
+                    <field name="nondeductible"/>
+                </field>
+            </field>
+        </record>
 
-      <record id="view_account_form_inverse" model="ir.ui.view">
-          <field name="name">account.form.inverse</field>
-          <field name="model">account.account</field>
-          <field name="inherit_id" ref="account.view_account_form"></field>
-          <field name="type">form</field>
-          <field name="arch" type="xml">
-              <field name="user_type" position="after">
-                  <field name="inverse_user_type"/>
-                  <field name="inverse_parent_id"/>
-              </field>
-          </field>
-      </record>
+        <record id="view_account_form_inverse" model="ir.ui.view">
+            <field name="name">account.form.inverse</field>
+            <field name="model">account.account</field>
+            <field name="inherit_id" ref="account.view_account_form" />
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <field name="user_type" position="after">
+                    <field name="inverse_user_type"/>
+                    <field name="inverse_parent_id"/>
+                    <field name="refund_invoice_account_id"/>
+                </field>
+            </field>
+        </record>
+
+        <record id="l10n_it_account_account_search_view" model="ir.ui.view">
+            <field name="name">l10n.it.account.account.search.view</field>
+            <field name="model">account.account</field>
+            <field name="inherit_id" ref="account.view_account_search" />
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <field name="user_type" position="before">
+                    <field name="type"/>
+                </field>
+
+                <field name="user_type" position="after">
+                    <field name="parent_id"/>
+                    <field name="refund_invoice_account_id"/>
+                </field>
+            </field>
+        </record>
 
     </data>
 </openerp>

--- a/l10n_it_account/views/config_view.xml
+++ b/l10n_it_account/views/config_view.xml
@@ -5,7 +5,7 @@
         <record id="view_l10n_it_config_settings" model="ir.ui.view">
             <field name="name">l10n_it settings</field>
             <field name="model">l10n_it.config.settings</field>
-            <field name="inherit_id" ref="l10n_it_base.view_l10n_it_config_settings"></field>
+            <field name="inherit_id" ref="l10n_it_base.view_l10n_it_config_settings" />
             <field name="arch" type="xml">
                 <xpath expr="/form/group[2]/div" position="inside">
                     <div>

--- a/l10n_it_account/views/res_partner_view.xml
+++ b/l10n_it_account/views/res_partner_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <!-- Add vat to search fields -->
+        <record id="l10n_it_account_res_partner_search_view" model="ir.ui.view">
+            <field name="name">l10n.it.account.res.partner.search.view</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="base.view_res_partner_filter"/>
+            <field name="arch" type="xml">
+                <field name="parent_id" position="after">
+                    <field name="vat" />
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
…s chart

 [IMP] new field refund_invoice_account_id added to use it in refund invoice
       instead of the main account. Italian profit and loss accounts
       must be used as credit accounts or debit accounts only.

 [FIX] removed blanks at the end of vat during save
 [ADD] added vat field to partner search view
 [FIX] translations