### PR TITLE
[8.0][ADD] l10n_it_account_partner_type

### DIFF
--- a/l10n_it_account_partner_type/README.rst
+++ b/l10n_it_account_partner_type/README.rst
@@ -1,0 +1,50 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+===========================================
+Italian Localization - Account Partner Type
+===========================================
+
+This module adds a fiscal partner type field to partner. This field helps users
+to compile partner contacts with the right data.
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/122/8.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/l10n-italy/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/l10n-italy/issues/new?body=module:%20l10n_it_account%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Domenico Stragapede <d.stragapede@elvenstudio.it>
+* Vincenzo Terzulli <v.terzulli@elvenstudio.it>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/l10n_it_account_partner_type/__init__.py
+++ b/l10n_it_account_partner_type/__init__.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2018 ElvenStudio S.n.c. (<http://www.elvenstudio.it>)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import models
+
+import logging
+from openerp import SUPERUSER_ID
+
+
+def post_init_hook(cr, registry):
+    _logger = logging.getLogger('openerp.addons.l10n_it_account_partner_type')
+
+    res_partner_model = registry['res.partner']
+    _logger.info('Setting values for res.partner new field: Partner Type')
+    # By default, all partners will be set to contact
+
+    _logger.info('Setting partners of type person')
+    # Case a: person
+    # type is person -> fiscalcode not is empty and
+    #                   vat is empty and
+    #                   parent_id is false and
+    #                   is_pa is false
+    #
+    # All persons have a fiscalcode set and
+    # they are not a company or public administration and
+    # the field vat must be empty
+
+    # add parent_id condition in order to exclude sub account
+    partner_person_domain = [
+        ('fiscalcode', '!=', False),
+        ('vat', '=', False),
+        ('parent_id', '=', False),
+        ('is_pa', '=', False)
+    ]
+    partner_person_vals = {
+        'partner_type': 'person',
+        'vat_subjected': False,
+        'individual': True,
+        'is_company': False
+    }
+    partner_person_ids = res_partner_model.search(cr, SUPERUSER_ID, partner_person_domain)
+    res_partner_model.write(cr, SUPERUSER_ID, partner_person_ids, partner_person_vals)
+    _logger.info('Partners of type person correctly sets')
+
+    _logger.info('Setting partners of type individual')
+    # Case b: individual
+    # type is individual -> fiscalcode length equal to 16 and
+    #                       vat is not empty and
+    #                       vat is not equal to fiscalcode and
+    #                       parent_id is set
+    #
+    # Individual companies are company related to a single person,
+    # so we need to have the company vat number and the person fiscalcode.
+    partner_individual_domain = [
+        ('fiscalcode', '!=', False),
+        ('vat', '!=', False),
+        ('parent_id', '=', False)
+    ]
+    partner_individual_vals = {
+        'partner_type': 'individual',
+        'vat_subjected': True,
+        'individual': True,
+        'is_company': True
+    }
+    partner_individual_ids = res_partner_model.search(cr, SUPERUSER_ID, partner_individual_domain)
+    partner_individuals = res_partner_model.browse(cr, SUPERUSER_ID, partner_individual_ids)
+    partner_individual_to_update_ids = []
+    for partner in partner_individuals:
+        if partner.vat != partner.fiscalcode and len(partner.fiscalcode) == 16:
+            partner_individual_to_update_ids.append(partner.id)
+
+    res_partner_model.write(cr, SUPERUSER_ID, partner_individual_to_update_ids, partner_individual_vals)
+    _logger.info('Partners of type individual correctly sets')
+
+    _logger.info('Setting partners of type company')
+    # Case c: company
+    # type is company -> fiscalcode is not set or equal to vat and
+    #                    vat is not empty and
+    #                    parent_id is not set and
+    #                    is_pa is false
+    #
+    # Italian companies can have the fiscalcode equal to vat without
+    # the country suffix (eg. vat: IT0123456789 -> fiscalcode 0123456789).
+    partner_company_domain = [
+        ('vat', '!=', False),
+        ('parent_id', '=', False),
+        ('is_pa', '=', False),
+    ]
+    partner_company_vals = {
+        'partner_type': 'company',
+        'vat_subjected': True,
+        'is_company': True,
+        'individual': False
+    }
+    partner_company_ids = res_partner_model.search(cr, SUPERUSER_ID, partner_company_domain)
+    partner_companies = res_partner_model.browse(cr, SUPERUSER_ID, partner_company_ids)
+    partner_company_to_update_ids = []
+    for partner in partner_companies:
+        if partner.vat == partner.fiscalcode or \
+           partner.fiscalcode in partner.vat or \
+           not partner.fiscalcode:
+            partner_company_to_update_ids.append(partner.id)
+
+    res_partner_model.write(cr, SUPERUSER_ID, partner_company_to_update_ids, partner_company_vals)
+    _logger.info('Partners of type company correctly sets')
+
+    _logger.info('Setting partners of type public administration')
+    # Case d: public administration
+    # type is company -> fiscalcode is set and
+    #                    parent_id is not set and
+    #                    is_pa is True or ipa_code is set
+    #
+    # Some italian public administration does not have vat, but only fiscalcode
+    # must be always available. In addition, contact can have the ipa code set
+    # but is_pa field sets to false to l10n_it_ipa module.
+    partner_public_domain = [
+        ('fiscalcode', '!=', False),
+        ('parent_id', '=', False),
+        '|',
+        ('is_pa', '=', True),
+        ('ipa_code', '=', True),
+    ]
+    partner_public_vals = {
+        'partner_type': 'public',
+        'vat_subjected': False,
+        'is_company': True,
+        'individual': False,
+        'is_pa': True,
+    }
+    partner_public_ids = res_partner_model.search(cr, SUPERUSER_ID, partner_public_domain)
+    res_partner_model.write(cr, SUPERUSER_ID, partner_public_ids, partner_public_vals)
+    _logger.info('Partners of type public administration correctly sets')
+
+    _logger.info('Fields setup completed')

--- a/l10n_it_account_partner_type/__openerp__.py
+++ b/l10n_it_account_partner_type/__openerp__.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2018 ElvenStudio S.n.c. (<http://www.elvenstudio.it>)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': 'Italian Localization - Account Partner Type',
+    'version': '8.0.1.0.0',
+    'category': 'Hidden',
+    'author': "Elven Studio s.n.c.",
+    'website': 'http://www.elvenstudio.it',
+    'license': 'AGPL-3',
+    "depends": [
+        'l10n_it_account',
+        # 'l10n_it_fiscalcode',  # already satisfied by l10n_it_account
+        'l10n_it_ipa',
+        'partner_firstname',
+    ],
+
+    "data": [
+        'views/res_partner_view.xml',
+    ],
+
+    'installable': True,
+    # this post_init script only works when you install account and
+    # l10n_it_account_partner_type in 2 different instants
+    'post_init_hook': 'post_init_hook',
+}

--- a/l10n_it_account_partner_type/i18n/it.po
+++ b/l10n_it_account_partner_type/i18n/it.po
@@ -1,0 +1,120 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * l10n_it_account_partner_type
+#
+# Translators:
+# Domenico Stragapede <d.stragapede@elvenstudio.it>, 2018
+msgid ""
+msgstr ""
+"Project-Id-Version: l10n-italy (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-12-30 12:40+0000\n"
+"PO-Revision-Date: 2018-12-30 12:40+0000\n"
+"Last-Translator: Domenico Stragapede\n"
+"Language-Team: Italian (http://www.transifex.com/oca/OCA-l10n-italy-8-0/"
+"language/it/)\n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: l10n_it_account_partner_type
+#: code:addons/l10n_it_account_partner_type/models/res_partner.py:38
+#, python-format
+msgid "Choose the partner type due to your needed, in order to fill the right fields.\n"
+" - Generic Contact: generic partner without any fiscal information.\n"
+" - Company: Company contact, use this when registering a new company.\n"
+" - Individual Company: A company that has fiscal information related to a person.\n"
+" - Public administration: A company that has fiscal information related to a public organization.\n"
+" - Person: A private citizen contact, used in sale or purchase invoices."
+msgstr "Scegli il tipo di contatto in base alle tue esigenze, così da inserire i dati nei giusti campi.\n"
+" - Contatto generico: partner generico senza dati fiscali.\n"
+" - Azienda: Contatto aziendale, usa questo tipo quando registri una nuova azienda.\n"
+" - Ditta individuale: Un'azienda che ha i dati fiscali relativi ad una persona fisica.\n"
+" - Pubblica amministrazione: un'azienda che ha i dati fiscali relativi ad una pubblica amministrazione.\n"
+" - Persona fisica: Un contatto di una persona fisica, usata nelle fatture di vendita o acquisto."
+
+#. module: l10n_it_account_partner_type
+#: code:addons/l10n_it_account_partner_type/models/res_partner.py:31
+#: view:res.partner:l10n_it_account_partner_type.l10n_it_account_partner_type_res_partner_search_view
+#, python-format
+msgid "Company"
+msgstr "Azienda"
+
+#. module: l10n_it_account_partner_type
+#: view:res.partner:l10n_it_account_partner_type.l10n_it_account_partner_type_res_partner_search_view
+msgid "Contact"
+msgstr "Contatto"
+
+#. module: l10n_it_account_partner_type
+#: view:res.partner:l10n_it_account_partner_type.l10n_it_account_partner_type_res_partner_search_view
+msgid "Contact Type"
+msgstr "Tipo Anagrafica"
+
+#. module: l10n_it_account_partner_type
+#: view:res.partner:l10n_it_account_partner_type.l10n_it_account_partner_type_fiscal_data_form_view
+msgid "Fiscal Data"
+msgstr "Dati Fiscali"
+
+#. module: l10n_it_account_partner_type
+#: code:addons/l10n_it_account_partner_type/models/res_partner.py:30
+#, python-format
+msgid "Generic Contact"
+msgstr "Contatto Generico"
+
+#. module: l10n_it_account_partner_type
+#: view:res.partner:l10n_it_account_partner_type.l10n_it_account_partner_type_res_partner_search_view
+msgid "Individual"
+msgstr "Individuale"
+
+#. module: l10n_it_account_partner_type
+#: code:addons/l10n_it_account_partner_type/models/res_partner.py:32
+#, python-format
+msgid "Individual Company"
+msgstr "Ditta Individuale"
+
+#. module: l10n_it_account_partner_type
+#: model:ir.model,name:l10n_it_account_partner_type.model_res_partner
+msgid "Partner"
+msgstr "Partner"
+
+#. module: l10n_it_account_partner_type
+#: code:addons/l10n_it_account_partner_type/models/res_partner.py:28
+#, python-format
+msgid "Partner Type"
+msgstr "Tipo di partner"
+
+#. module: l10n_it_account_partner_type
+#: code:addons/l10n_it_account_partner_type/models/res_partner.py:34
+#: view:res.partner:l10n_it_account_partner_type.l10n_it_account_partner_type_res_partner_search_view
+#, python-format
+msgid "Person"
+msgstr "Persona Fisica"
+
+#. module: l10n_it_account_partner_type
+#: view:res.partner:l10n_it_account_partner_type.l10n_it_account_partner_type_res_partner_search_view
+msgid "Public"
+msgstr "Pubblica"
+
+#. module: l10n_it_account_partner_type
+#: code:addons/l10n_it_account_partner_type/models/res_partner.py:33
+#, python-format
+msgid "Public Administration"
+msgstr "Pubblica amministrazione"
+
+#. module: l10n_it_account_partner_type
+#: view:res.partner:l10n_it_account_partner_type.l10n_it_account_partner_type_fiscal_data_form_view
+msgid "{'invisible': [('partner_type', '=', 'contact')]}"
+msgstr "{'invisible': [('partner_type', '=', 'contact')]}"
+
+#. module: l10n_it_account_partner_type
+#: view:res.partner:l10n_it_account_partner_type.l10n_it_account_partner_type_fiscal_data_form_view
+msgid "{'required': [('partner_type', '!=', 'contact')]}"
+msgstr "{'required': [('partner_type', '!=', 'contact')]}"
+
+#. module: l10n_it_account_partner_type
+#: view:res.partner:l10n_it_account_partner_type.l10n_it_account_partner_type_partner_firstname_form_view
+msgid "{'required': [('partner_type', 'in', ['person', 'individual'])], 'invisible': [('partner_type', 'not in', ['contact', 'person', 'individual'])]}"
+msgstr "{'required': [('partner_type', 'in', ['person', 'individual'])], 'invisible': [('partner_type', 'not in', ['contact', 'person', 'individual'])]}"
+

--- a/l10n_it_account_partner_type/i18n/l10n_it_account_partner_type.pot
+++ b/l10n_it_account_partner_type/i18n/l10n_it_account_partner_type.pot
@@ -1,0 +1,111 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* l10n_it_account_partner_type
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-12-30 12:40+0000\n"
+"PO-Revision-Date: 2018-12-30 12:40+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_it_account_partner_type
+#: code:addons/l10n_it_account_partner_type/models/res_partner.py:38
+#, python-format
+msgid "Choose the partner type due to your needed, in order to fill the right fields.\n"
+" - Generic Contact: generic partner without any fiscal information.\n"
+" - Company: Company contact, use this when registering a new company.\n"
+" - Individual Company: A company that has fiscal information related to a person.\n"
+" - Public administration: A company that has fiscal information related to a public organization.\n"
+" - Person: A private citizen contact, used in sale or purchase invoices."
+msgstr ""
+
+#. module: l10n_it_account_partner_type
+#: code:addons/l10n_it_account_partner_type/models/res_partner.py:31
+#: view:res.partner:l10n_it_account_partner_type.l10n_it_account_partner_type_res_partner_search_view
+#, python-format
+msgid "Company"
+msgstr ""
+
+#. module: l10n_it_account_partner_type
+#: view:res.partner:l10n_it_account_partner_type.l10n_it_account_partner_type_res_partner_search_view
+msgid "Contact"
+msgstr ""
+
+#. module: l10n_it_account_partner_type
+#: view:res.partner:l10n_it_account_partner_type.l10n_it_account_partner_type_res_partner_search_view
+msgid "Contact Type"
+msgstr ""
+
+#. module: l10n_it_account_partner_type
+#: view:res.partner:l10n_it_account_partner_type.l10n_it_account_partner_type_fiscal_data_form_view
+msgid "Fiscal Data"
+msgstr ""
+
+#. module: l10n_it_account_partner_type
+#: code:addons/l10n_it_account_partner_type/models/res_partner.py:30
+#, python-format
+msgid "Generic Contact"
+msgstr ""
+
+#. module: l10n_it_account_partner_type
+#: view:res.partner:l10n_it_account_partner_type.l10n_it_account_partner_type_res_partner_search_view
+msgid "Individual"
+msgstr ""
+
+#. module: l10n_it_account_partner_type
+#: code:addons/l10n_it_account_partner_type/models/res_partner.py:32
+#, python-format
+msgid "Individual Company"
+msgstr ""
+
+#. module: l10n_it_account_partner_type
+#: model:ir.model,name:l10n_it_account_partner_type.model_res_partner
+msgid "Partner"
+msgstr ""
+
+#. module: l10n_it_account_partner_type
+#: code:addons/l10n_it_account_partner_type/models/res_partner.py:28
+#, python-format
+msgid "Partner Type"
+msgstr ""
+
+#. module: l10n_it_account_partner_type
+#: code:addons/l10n_it_account_partner_type/models/res_partner.py:34
+#: view:res.partner:l10n_it_account_partner_type.l10n_it_account_partner_type_res_partner_search_view
+#, python-format
+msgid "Person"
+msgstr ""
+
+#. module: l10n_it_account_partner_type
+#: view:res.partner:l10n_it_account_partner_type.l10n_it_account_partner_type_res_partner_search_view
+msgid "Public"
+msgstr ""
+
+#. module: l10n_it_account_partner_type
+#: code:addons/l10n_it_account_partner_type/models/res_partner.py:33
+#, python-format
+msgid "Public Administration"
+msgstr ""
+
+#. module: l10n_it_account_partner_type
+#: view:res.partner:l10n_it_account_partner_type.l10n_it_account_partner_type_fiscal_data_form_view
+msgid "{'invisible': [('partner_type', '=', 'contact')]}"
+msgstr ""
+
+#. module: l10n_it_account_partner_type
+#: view:res.partner:l10n_it_account_partner_type.l10n_it_account_partner_type_fiscal_data_form_view
+msgid "{'required': [('partner_type', '!=', 'contact')]}"
+msgstr ""
+
+#. module: l10n_it_account_partner_type
+#: view:res.partner:l10n_it_account_partner_type.l10n_it_account_partner_type_partner_firstname_form_view
+msgid "{'required': [('partner_type', 'in', ['person', 'individual'])], 'invisible': [('partner_type', 'not in', ['contact', 'person', 'individual'])]}"
+msgstr ""
+

--- a/l10n_it_account_partner_type/models/__init__.py
+++ b/l10n_it_account_partner_type/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import res_partner

--- a/l10n_it_account_partner_type/models/res_partner.py
+++ b/l10n_it_account_partner_type/models/res_partner.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+#
+#
+#    Copyright (C) 2018 Elven Studio (<http://www.elvenstudio.it>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+from openerp import models, fields, api, _
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    partner_type = fields.Selection(
+        string=_('Partner Type'),
+        selection=[
+            ('contact', _('Generic Contact')),
+            ('company', _('Company')),
+            ('individual', _('Individual Company')),
+            ('public', _('Public Administration')),
+            ('person', _('Person')),
+        ],
+        default='contact',
+        required=True,
+        help=_(
+            'Choose the partner type due to your needed, '
+            'in order to fill the right fields.\n'
+            ' - Generic Contact: generic partner without any fiscal information.\n'
+            ' - Company: Company contact, use this when registering a new company.\n'
+            ' - Individual Company: A company that has fiscal information related to a person.\n'
+            ' - Public administration: A company that has fiscal information related to a public organization.\n'
+            ' - Person: A private citizen contact, used in sale or purchase invoices.'
+        )
+    )
+
+    @api.one
+    @api.onchange('partner_type')
+    def onchange_partner_type(self):
+        if self.partner_type == 'company':
+            self.is_company = True
+            self.vat_subjected = True
+            self.individual = False
+            self.is_pa = False
+        elif self.partner_type == 'individual':
+            self.is_company = True
+            self.vat_subjected = True
+            self.individual = True
+            self.is_pa = False
+        elif self.partner_type == 'person':
+            self.is_company = False
+            self.vat_subjected = False
+            self.individual = True
+            self.is_pa = False
+        elif self.partner_type == 'public':
+            self.is_company = True
+            self.vat_subjected = False
+            self.individual = False
+            self.is_pa = True
+        elif self.partner_type == 'contact':
+            self.is_company = False
+            self.vat_subjected = False
+            self.individual = False
+            self.is_pa = False
+

--- a/l10n_it_account_partner_type/views/res_partner_view.xml
+++ b/l10n_it_account_partner_type/views/res_partner_view.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <!-- Hide is_company boolean field from base -->
+        <record id="res_partner_hide_is_company_form_view" model="ir.ui.view">
+            <field name="name">res.partner.hide.is.company.form.view</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="base.view_partner_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//div[@class='oe_title oe_left']/div[@class='oe_edit_only']" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </xpath>
+            </field>
+        </record>
+
+        <!-- Hide vat_subjected boolean field from base_vat -->
+        <record id="res_partner_hide_vat_subjected_form_view" model="ir.ui.view">
+            <field name="name">res.partner.hide.vat.subjected.form.view</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="base_vat.view_partner_form"/>
+            <field name="arch" type="xml">
+                <field name="vat_subjected" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </field>
+            </field>
+        </record>
+
+        <!-- Hide individual boolean field from l10n_it_fiscalcode -->
+        <record id="res_partner_hide_individual_form_view" model="ir.ui.view">
+            <field name="name">res.partner.hide.individual.form.view</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="l10n_it_fiscalcode.view_partner_form_fiscalcode_data"/>
+            <field name="arch" type="xml">
+                <span name="individual_field" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </span>
+            </field>
+        </record>
+
+        <!-- Hide is_pa boolean field from l10n_it_ipa -->
+        <record id="res_partner_hide_is_pa_form_view" model="ir.ui.view">
+            <field name="name">res.partner.hide.is.pa.form.view</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="l10n_it_ipa.view_partner_ipa_form"/>
+            <field name="arch" type="xml">
+                <field name="is_pa" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </field>
+            </field>
+        </record>
+
+        <!-- Add partner type filters -->
+        <record id="l10n_it_account_partner_type_res_partner_search_view" model="ir.ui.view">
+            <field name="name">l10n.it.account.partner.type.res.partner.search.view</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="base.view_res_partner_filter"/>
+            <field name="arch" type="xml">
+                <field name="parent_id" position="after">
+                    <field name="partner_type" />
+                    <group expand="0" string="Contact Type">
+                        <filter string="Contact"  domain="[('partner_type','=','contact')]"/>
+                        <filter string="Company"  domain="[('partner_type','=','company')]"/>
+                        <filter string="Individual"  domain="[('partner_type','=','individual')]"/>
+                        <filter string="Public"  domain="[('partner_type','=','public')]"/>
+                        <filter string="Person"  domain="[('partner_type','=','person')]"/>
+                        <separator/>
+                    </group>
+                </field>
+            </field>
+        </record>
+
+        <!-- Hide fiscal fields when partner type is person -->
+        <record id="l10n_it_account_partner_type_fiscal_data_form_view" model="ir.ui.view">
+            <field name="name">l10n.it.account.partner.type.fiscal.data.form.view</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="account.view_partner_property_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//page[@name='accounting']/group/group" position="attributes">
+                    <attribute name="string">Fiscal Data</attribute>
+                    <attribute name="attrs">{'invisible': [('partner_type', '=', 'contact')]}</attribute>
+                </xpath>
+                <field name="property_account_position" position="attributes">
+                    <attribute name="attrs">{'required': [('partner_type', '!=', 'contact')]}</attribute>
+                </field>
+            </field>
+        </record>
+
+        <!-- Adds partner type to the form view -->
+        <record id="l10n_it_account_partner_type_form_view" model="ir.ui.view">
+            <field name="name">l10n.it.account.partner.type.form.view</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="base.view_partner_form"/>
+            <field name="arch" type="xml">
+                <field name="parent_id" position="before">
+                    <field name="partner_type" />
+                </field>
+            </field>
+        </record>
+
+        <!-- Firstname and Lastname required when contact is person or individual -->
+        <record id="l10n_it_account_partner_type_partner_firstname_form_view" model="ir.ui.view">
+            <field name="name">l10n.it.account.partner.type.partner.firstname.form.view</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="partner_firstname.view_partner_form_firstname"/>
+            <field name="arch" type="xml">
+                <!-- TODO enable if partner_firstname uses the split action -->
+                <!--<button string="Split name" position="attributes">-->
+                    <!--<attribute name="attrs">{'required': [('partner_type', 'in', ['person', 'individual'])], 'invisible': [('partner_type', 'not in', ['contact', 'person', 'individual'])]}</attribute>-->
+                <!--</button>-->
+
+                <field name="firstname" position="attributes">
+                    <attribute name="attrs">{'required': [('partner_type', 'in', ['person', 'individual'])], 'invisible': [('partner_type', 'not in', ['contact', 'person', 'individual'])]}</attribute>
+                </field>
+
+                <field name="lastname" position="attributes">
+                    <attribute name="attrs">{'required': [('partner_type', 'in', ['person', 'individual'])], 'invisible': [('partner_type', 'not in', ['contact', 'person', 'individual'])]}</attribute>
+                </field>
+
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
 New module for better partner data entry.

 [IMP] new selection field partner_type in partner to helps users
       to define the type of partner created.
 [IMP] Module integrated with base_vat, l10n_it_fiscalcode, l10n_it_ipa
       in oder to hide the fields that will be set automatically with partner_type.