### PR TITLE
[8.0][FIX] l10n_it_fatturapa_out: get_pdf NoneType error

### DIFF
--- a/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
+++ b/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
@@ -827,13 +827,15 @@ class WizardExportFatturapa(models.TransientModel):
             int(self.report_print_menu.value.split(',')[1]))
         action_report = self.env[action_report_model] \
             .browse(action_report_id)
-        report_model = self.env['report']
+        report_model = self.pool['report']
         attachment_model = self.env['ir.attachment']
         # Generate the PDF: if report_action.attachment is set
         # they will be automatically attached to the invoice,
         # otherwise use res to build a new attachment
-        res = report_model.get_pdf(inv, action_report.report_name, html=None,
-                                   data=None)
+        res = report_model.get_pdf(
+            self._cr, self._uid, inv.ids,
+            action_report.report_name, data=None, context=self.env.context)
+
         if action_report.attachment:
             # If the report is configured to be attached
             # to the current invoice, just get that from the attachments.
@@ -841,7 +843,7 @@ class WizardExportFatturapa(models.TransientModel):
             # fatturapa_doc_attachments is exactly the same
             # that is attached to the invoice.
             attachment = report_model._attachment_stored(
-                inv, action_report)[inv.id]
+                self._cr, self._uid, inv, action_report)[inv.id]
         else:
             # Otherwise, create a new attachment to be stored in
             # fatturapa_doc_attachments.


### PR DESCRIPTION
 When try to generate xml e-invoice with pdf attachment, odoo returns a
 NoneType error on report_model object. This fix allows to generate pdf
 and attach it correctly.