### PR TITLE
[8.0][FIX] l10n_it_fatturapa

### DIFF
--- a/l10n_it_fatturapa/views/partner_view.xml
+++ b/l10n_it_fatturapa/views/partner_view.xml
@@ -14,8 +14,7 @@
                             <group attrs="{'invisible': [('electronic_invoice_subjected', '=', False)]}">
                                 <field name="ipa_code" placeholder="IPA123" attrs="{'invisible': [('is_pa','=', False)]}"/>
                                 <field name="codice_destinatario" attrs="{'invisible': [('is_pa', '=', True)]}"/>
-                                <field name="pec_destinatario"
-                                       attrs="{'invisible': ['|',('is_pa', '=', True), ('codice_destinatario', '!=', '0000000')]}"/>
+                                <field name="pec_destinatario" attrs="{'invisible': [('is_pa', '=', True)]}"/>
                                 <field name="eori_code"/>
                             </group>
                         </group>


### PR DESCRIPTION
 [FIX] removed codice_destinatario condition because pec_destinatario
       should be mandatory and always visible if the partner is subjected
       to electronic invoice