### PR TITLE
[8.0][FIX] l10n_it_fatturapa_pec: Cron export invoices to public

### DIFF
--- a/l10n_it_fatturapa_pec/models/fatturapa_attachment_out.py
+++ b/l10n_it_fatturapa_pec/models/fatturapa_attachment_out.py
@@ -296,7 +296,11 @@ class FatturaPAAttachmentOut(models.Model):
 
             # export XML file and send via PEC
             wizard.exportFatturaPA()
-            invoices.mapped('fatturapa_attachment_out_id').send_via_pec()
+
+            # filter public administration invoices,
+            # because they need to be signed before send
+            invoices_to_send = invoices.filtered(lambda i: not i.partner_id.is_pa)
+            invoices_to_send.mapped('fatturapa_attachment_out_id').send_via_pec()
 
         return True
 


### PR DESCRIPTION
 [FIX] excluded public administration invoices from auto send, because
       they need to be signed before send.