### PR TITLE
[8.0][FIX] l10n_it_vat_communication

### DIFF
--- a/l10n_it_vat_communication/models/account.py
+++ b/l10n_it_vat_communication/models/account.py
@@ -769,7 +769,8 @@ class commitment_line(orm.AbstractModel):
                     _('Partner %s without Fiscalcode') % (partner.name))
         else:
             res['xml_Denominazione'] = partner.name
-            if not partner.vat:
+            # avoid check for non-profit organizations
+            if not partner.vat and not partner.fiscalcode:
                 raise orm.except_orm(
                     _('Error!'),
                     _('Partner %s without VAT number') % (partner.name))


### PR DESCRIPTION
 * check vat only for partners that does not have a fiscalcode set
 (used for non-profit organization).